### PR TITLE
#119 CI maintenance: clean up cspell.json and Slack notification wiring

### DIFF
--- a/.github/workflows/docker-push-containers-to-dockerhub-and-ecr.yaml
+++ b/.github/workflows/docker-push-containers-to-dockerhub-and-ecr.yaml
@@ -9,8 +9,6 @@ permissions: {}
 
 jobs:
   docker-push-containers-to-dockerhub-and-ecr:
-    outputs:
-      status: ${{ job.status }}
     permissions:
       attestations: write
       contents: write
@@ -33,10 +31,10 @@ jobs:
 
   slack-notification:
     needs: [docker-push-containers-to-dockerhub-and-ecr]
-    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.docker-push-containers-to-dockerhub-and-ecr.outputs.status) }}
+    if: ${{ always() && contains(fromJSON('["failure", "cancelled"]'), needs.docker-push-containers-to-dockerhub-and-ecr.result) }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     uses: senzing-factory/build-resources/.github/workflows/build-failure-slack-notification.yaml@v4
     with:
-      job-status: ${{ needs.docker-push-containers-to-dockerhub-and-ecr.outputs.status }}
+      job-status: ${{ needs.docker-push-containers-to-dockerhub-and-ecr.result }}

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -10,7 +10,6 @@
     "Dockerfiles",
     "dockerhub",
     "docktermj",
-    "esbenp",
     "ICLA",
     "kernelsam",
     "libpostal",
@@ -29,5 +28,7 @@
     "toplevel",
     "venv"
   ],
-  "ignorePaths": [".git/**"]
+  "ignorePaths": [
+    ".git/**"
+  ]
 }


### PR DESCRIPTION
## Summary
- Remove unused words from `.vscode/cspell.json`
- Use `needs.<job>.result` instead of `needs.<job>.outputs.status` for Slack notifications

Closes #119

---

Resolves #119